### PR TITLE
pinFileToIpfs with InputStream

### DIFF
--- a/src/main/java/util/InputStreamRequestBody.java
+++ b/src/main/java/util/InputStreamRequestBody.java
@@ -1,0 +1,42 @@
+package util;
+
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import okio.BufferedSink;
+import okio.Okio;
+import okio.Source;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class InputStreamRequestBody extends RequestBody {
+
+    private final InputStream inputStream;
+    private final MediaType contentType;
+
+    private InputStreamRequestBody(InputStream inputStream, MediaType contentType) {
+        this.inputStream = inputStream;
+        this.contentType = contentType;
+    }
+
+    public static RequestBody create(InputStream inputStream, MediaType contentType) {
+        return new InputStreamRequestBody(inputStream, contentType);
+    }
+
+    @Override
+    public MediaType contentType() {
+        return contentType;
+    }
+
+    @Override
+    public boolean isOneShot() {
+        return true;
+    }
+
+    @Override
+    public void writeTo(BufferedSink sink) throws IOException {
+        try (Source source = Okio.source(inputStream)) {
+            sink.writeAll(source);
+        }
+    }
+}


### PR DESCRIPTION
Added public methods to pin a file to ipfs by passing a reference to an InputStream and a filename, instead of a reference to a File, which implied that the file must be written to disk.
My use case for the InputStream was a feature that required some in-memory processing on a file before pinning the content to ipfs.

The current implementation delegates the methods with File in the signature to the "more generic" methods with InputStream.
There is a small caveat, though: the http request constructed with an InputStream is "one shot" and non-replyable by okhttp, since when an InputStream is consumed, it can't be consumed again.
The previous implementation with File was replyable by okhttp, which to my understanding retries to send the request in some circumstances (some errors / networking problems).
I don't know if this was an intentional/wanted behavior.